### PR TITLE
Check for an undefined type on the destroy callback

### DIFF
--- a/src/cal-heatmap.js
+++ b/src/cal-heatmap.js
@@ -2865,7 +2865,7 @@ CalHeatMap.prototype = {
 			.each("end", function() {
 				if (typeof callback === "function") {
 					callback();
-				} else if (callback !== undefined) {
+				} else if (typeof callback !== "undefined") {
 					console.log("Provided callback for destroy() is not a function.");
 				}
 			})


### PR DESCRIPTION
...instead of checking for equality to the global `undefined` value.

Another option would be to not check strict equality (i.e. use `==` vs. `===`), but this form is generally preferred.

[This change](https://github.com/kamisama/cal-heatmap/commit/17be31f3b889e576815f965d775ee70e71b657fa) results in the log entry being made when `destroy` is called with no arguments.

See [this doc](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined#Typeof_operator_and_undefined)