### PR TITLE
Remove trailing comma in object literal

### DIFF
--- a/src/cal-heatmap.js
+++ b/src/cal-heatmap.js
@@ -531,7 +531,7 @@ var CalHeatMap = function() {
 				column: d.row,
 				position: {
 					x: d.position.y,
-					y: d.position.x,
+					y: d.position.x
 				},
 				format: d.format,
 				extractUnit: d.extractUnit


### PR DESCRIPTION
While a trailing comma is valid since ES5, they are not well supported by old IE versions.
Also, some js optimizers can complain about them, and even refuse to generate an output.

It is the only occurrence, and removing it did allow the google-closure compiler to process the file.
